### PR TITLE
Analyze command, automatic ID's, global insecure flag, Microsecond time and some cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ NOTE: Be careful not to re-use the ID's if you care about fetching results at a 
 # get test results
 ./hperf stat --hosts 1.1.1.{1...100} --id [my_test_id]
 # save test results
-./hperf stat --hosts 1.1.1.{1...100} --id [my_test_id] --output /tmp/file
+./hperf stat --hosts 1.1.1.{1...100} --id [my_test_id] --output /tmp/test.out
+
+# analyze test results
+./hperf analyze --file /tmp/test.out
 
 # listen in on a running test
 ./hperf listen --hosts 1.1.1.{1...100} --id [my_test_id]
@@ -96,6 +99,13 @@ NOTE: Be careful not to re-use the ID's if you care about fetching results at a 
 # stop a running test
 ./hperf stop --hosts 1.1.1.{1...100} --id [my_test_id]
 ```
+
+## Analysis
+The analyze command will print statistics for the 10th and 90th percentiles and all datapoints in between. 
+The format used is:
+ - 10th percentile: total, low, avarage, high
+ - in between: total, low, avarage, high
+ - 90th percentile: total, low, avarage, high
 
 ## Available Statistics
  - Payload Roundtrip (RMS high/low): 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ NOTE: Be careful not to re-use the ID's if you care about fetching results at a 
 ```
 
 ## Available Statistics
- - Payload Roundtrip (PMS high/low): 
-   - Payload transfer time (Milliseconds)
+ - Payload Roundtrip (RMS high/low): 
+   - Payload transfer time (Microseconds)
  - Time to first byte (TTFB high/low): 
-   - This is the amount of time (Milliseconds) it takes between a request being made and the first byte being requested by the receiver
+   - This is the amount of time (Microseconds) it takes between a request being made and the first byte being requested by the receiver
  - Transferred bytes (TX): 
    - Bandwidth throughput in KB/s, MB/s, GB/s, etc..
  - Request count (#TX): 

--- a/client/table.go
+++ b/client/table.go
@@ -65,12 +65,12 @@ func initHeaders() {
 	headerSlice[Created] = header{"Created", 8}
 	headerSlice[Local] = header{"Local", 15}
 	headerSlice[Remote] = header{"Remote", 15}
-	headerSlice[PMSH] = header{"PMSH", 4}
-	headerSlice[PMSL] = header{"PMSL", 4}
-	headerSlice[TTFBH] = header{"TTFBH", 5}
-	headerSlice[TTFBL] = header{"TTFBL", 5}
-	headerSlice[TX] = header{"TX", 9}
-	headerSlice[TXCount] = header{"#TX", 6}
+	headerSlice[PMSH] = header{"RMSH", 8}
+	headerSlice[PMSL] = header{"RMSL", 8}
+	headerSlice[TTFBH] = header{"TTFBH", 8}
+	headerSlice[TTFBL] = header{"TTFBL", 8}
+	headerSlice[TX] = header{"TX", 10}
+	headerSlice[TXCount] = header{"#TX", 10}
 	headerSlice[ErrCount] = header{"#ERR", 6}
 	headerSlice[DroppedPackets] = header{"#Dropped", 9}
 	headerSlice[MemoryUsage] = header{"MemUsed", 7}
@@ -148,8 +148,8 @@ func printTableRow(style lipgloss.Style, entry *shared.DP, t shared.TestType) {
 			column{entry.Created.Format("15:04:05"), headerSlice[Created].width},
 			column{strings.Split(entry.Local, ":")[0], headerSlice[Local].width},
 			column{strings.Split(entry.Remote, ":")[0], headerSlice[Remote].width},
-			column{formatInt(entry.PMSH), headerSlice[PMSH].width},
-			column{formatInt(entry.PMSL), headerSlice[PMSL].width},
+			column{formatInt(entry.RMSH), headerSlice[PMSH].width},
+			column{formatInt(entry.RMSL), headerSlice[PMSL].width},
 			column{formatUint(entry.TXCount), headerSlice[TXCount].width},
 			column{formatInt(int64(entry.ErrCount)), headerSlice[ErrCount].width},
 			column{formatInt(int64(entry.DroppedPackets)), headerSlice[DroppedPackets].width},
@@ -176,8 +176,8 @@ func printTableRow(style lipgloss.Style, entry *shared.DP, t shared.TestType) {
 			column{entry.Created.Format("15:04:05"), headerSlice[Created].width},
 			column{strings.Split(entry.Local, ":")[0], headerSlice[Local].width},
 			column{strings.Split(entry.Remote, ":")[0], headerSlice[Remote].width},
-			column{formatInt(entry.PMSH), headerSlice[PMSH].width},
-			column{formatInt(entry.PMSL), headerSlice[PMSL].width},
+			column{formatInt(entry.RMSH), headerSlice[PMSH].width},
+			column{formatInt(entry.RMSL), headerSlice[PMSL].width},
 			column{formatInt(entry.TTFBH), headerSlice[TTFBH].width},
 			column{formatInt(entry.TTFBL), headerSlice[TTFBH].width},
 			column{shared.BandwidthBytesToString(entry.TX), headerSlice[TX].width},

--- a/cmd/hperf/analyze.go
+++ b/cmd/hperf/analyze.go
@@ -140,6 +140,10 @@ func AnalyzeTest(ctx context.Context, c shared.Config) (err error) {
 		}
 	}
 
+	for i := range errors {
+		client.PrintTError(errors[i])
+	}
+
 	printBracker(dps10stats, "? < 10%", client.SuccessStyle)
 	printBracker(dps50stats, "10% < ? < 90%", client.WarningStyle)
 	printBracker(dps90stats, "? > 90%", client.ErrorStyle)

--- a/cmd/hperf/analyze.go
+++ b/cmd/hperf/analyze.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"slices"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/minio/cli"
+	"github.com/minio/hperf/client"
+	"github.com/minio/hperf/shared"
+)
+
+var analyzeCMD = cli.Command{
+	Name:   "analyze",
+	Usage:  "Analyze the give test",
+	Action: runAnalyze,
+	Flags: []cli.Flag{
+		dnsServerFlag,
+		hostsFlag,
+		portFlag,
+		fileFlag,
+	},
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Analyze test results in file '/tmp/latency-test-1':
+    {{.Prompt}} {{.HelpName}} --hosts 10.10.10.1 --file latency-test-1
+`,
+}
+
+func runAnalyze(ctx *cli.Context) error {
+	config, err := parseConfig(ctx)
+	if err != nil {
+		return err
+	}
+	return AnalyzeTest(GlobalContext, *config)
+}
+
+func AnalyzeTest(ctx context.Context, c shared.Config) (err error) {
+	_, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	f, err := os.Open(c.File)
+	if err != nil {
+		return err
+	}
+
+	dps := make([]shared.DP, 0)
+	errors := make([]shared.TError, 0)
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		b := s.Bytes()
+		if !bytes.Contains(b, []byte("Error")) {
+			dp := new(shared.DP)
+			err := json.Unmarshal(b, dp)
+			if err != nil {
+				return err
+			}
+			dps = append(dps, *dp)
+		} else {
+			dperr := new(shared.TError)
+			err := json.Unmarshal(b, dperr)
+			if err != nil {
+				return err
+			}
+			errors = append(errors, *dperr)
+		}
+	}
+
+	// adjust stats
+	for i := range dps {
+		// Highest RMSH can never be 0, but it's the default value of golang int64.
+		// if we find a 0 we just set it to an impossibly high value.
+		if dps[i].RMSH == 0 {
+			dps[i].RMSH = 999999999
+		}
+	}
+
+	dps10 := math.Ceil((float64(len(dps)) / 100) * 10)
+	dps90 := math.Floor((float64(len(dps)) / 100) * 90)
+
+	slices.SortFunc(dps, func(a shared.DP, b shared.DP) int {
+		if a.RMSH < b.RMSH {
+			return -1
+		} else {
+			return 1
+		}
+	})
+
+	dps10s := make([]shared.DP, 0)
+	dps50s := make([]shared.DP, 0)
+	dps90s := make([]shared.DP, 0)
+
+	// total, sum, low, mean, high
+	dps10stats := []int64{0, 0, 999999999, 0, 0}
+	dps50stats := []int64{0, 0, 999999999, 0, 0}
+	dps90stats := []int64{0, 0, 999999999, 0, 0}
+
+	for i := range dps {
+		if i <= int(dps10) {
+			dps10s = append(dps10s, dps[i])
+			updateBracketStats(dps10stats, dps[i])
+		} else if i >= int(dps90) {
+			dps90s = append(dps90s, dps[i])
+			updateBracketStats(dps90stats, dps[i])
+		} else {
+			dps50s = append(dps50s, dps[i])
+			updateBracketStats(dps50stats, dps[i])
+		}
+	}
+
+	printBracker(dps10stats, "? < 10%", client.SuccessStyle)
+	printBracker(dps50stats, "10% < ? < 90%", client.WarningStyle)
+	printBracker(dps90stats, "? > 90%", client.ErrorStyle)
+
+	return nil
+}
+
+func printBracker(b []int64, tag string, style lipgloss.Style) {
+	fmt.Println(style.Render(
+		fmt.Sprintf(" %s | Total %d | Low %d | Avg %d | High %d | Microseconds ",
+			tag,
+			b[0],
+			b[2],
+			b[3],
+			b[4],
+		),
+	))
+}
+
+func updateBracketStats(b []int64, dp shared.DP) {
+	b[0]++
+	b[1] += dp.RMSH
+	if dp.RMSH < b[2] {
+		b[2] = dp.RMSH
+	}
+	b[3] = b[1] / b[0]
+	if dp.RMSH > b[4] {
+		b[4] = dp.RMSH
+	}
+}

--- a/cmd/hperf/bandwidth.go
+++ b/cmd/hperf/bandwidth.go
@@ -35,7 +35,6 @@ var bandwidthCMD = cli.Command{
 		testIDFlag,
 		bufferSizeFlag,
 		payloadSizeFlag,
-		insecureFlag,
 		restartOnErrorFlag,
 		dnsServerFlag,
 		saveTestFlag,

--- a/cmd/hperf/latency.go
+++ b/cmd/hperf/latency.go
@@ -30,7 +30,6 @@ var latencyCMD = cli.Command{
 	Flags: []cli.Flag{
 		hostsFlag,
 		portFlag,
-		insecureFlag,
 		concurrencyFlag,
 		delayFlag,
 		durationFlag,
@@ -55,7 +54,7 @@ EXAMPLES:
    {{.Prompt}} {{.HelpName}} --hosts 10.10.10.1,10.10.10.2
 
   2. Run a slow moving test to probe latency:
-   {{.Prompt}} {{.HelpName}} --hosts 10.10.10.1,10.10.10.2 --delay 100
+   {{.Prompt}} {{.HelpName}} --hosts 10.10.10.1,10.10.10.2 --request-delay 100 --concurrency 1
 `,
 }
 

--- a/cmd/hperf/list.go
+++ b/cmd/hperf/list.go
@@ -42,7 +42,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. List all test on the '10.10.10.1':
+  1. List all test on the '10.10.10.1' host:
     {{.Prompt}} {{.HelpName}} --hosts 10.10.10.1
 `,
 }

--- a/cmd/hperf/requests.go
+++ b/cmd/hperf/requests.go
@@ -30,7 +30,6 @@ var requestsCMD = cli.Command{
 	Flags: []cli.Flag{
 		hostsFlag,
 		portFlag,
-		insecureFlag,
 		concurrencyFlag,
 		delayFlag,
 		durationFlag,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/hperf
 
-go 1.22.4
+go 1.22
 
 require (
 	github.com/charmbracelet/lipgloss v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,17 @@
 module github.com/minio/hperf
 
-go 1.22
+go 1.22.4
 
 require (
-	github.com/charmbracelet/lipgloss v0.12.1
+	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/fasthttp/websocket v1.5.10
 	github.com/gofiber/contrib/websocket v1.3.2
 	github.com/gofiber/fiber/v2 v2.52.5
+	github.com/google/uuid v1.6.0
 	github.com/minio/cli v1.24.2
 	github.com/minio/pkg/v3 v3.0.20
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	golang.org/x/sys v0.25.0
+	golang.org/x/sys v0.26.0
 )
 
 require (
@@ -18,7 +19,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/charmbracelet/lipgloss v0.12.1 h1:/gmzszl+pedQpjCOH+wFkZr/N90Snz40J/NR7A0zQcs=
-github.com/charmbracelet/lipgloss v0.12.1/go.mod h1:V2CiwIuhx9S1S1ZlADfOj9HmxeMAORuz5izHb0zGbB8=
+github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
+github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
 github.com/charmbracelet/x/ansi v0.1.4 h1:IEU3D6+dWwPSgZ6HBH+v6oUuZ/nVawMiWj5831KfiLM=
 github.com/charmbracelet/x/ansi v0.1.4/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -66,8 +66,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server/server.go
+++ b/server/server.go
@@ -421,8 +421,6 @@ type netPerfReader struct {
 	TTFBL int64
 	RMSH  int64
 	RMSL  int64
-	PH    int64
-	PL    int64
 
 	lastDataPointTime time.Time
 }

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -19,6 +19,7 @@ package shared
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -115,8 +116,8 @@ type DP struct {
 	Created           time.Time
 	Local             string
 	Remote            string
-	PMSH              int64
-	PMSL              int64
+	RMSH              int64
+	RMSL              int64
 	TTFBH             int64
 	TTFBL             int64
 	TX                uint64
@@ -127,7 +128,7 @@ type DP struct {
 	CPUUsedPercent    int
 
 	// Client only
-	Received time.Time
+	Received time.Time `json:"-"`
 }
 
 type DataReponseToClient struct {
@@ -152,6 +153,7 @@ type Config struct {
 	Insecure       bool          `json:"Insecure"`
 	TestType       TestType      `json:"TestType"`
 	Output         string        `json:"Output"`
+	File           string        `json:"File"`
 	// AllowLocalInterface bool          `json:"AllowLocalInterfaces"`
 
 	// Client Only
@@ -283,4 +285,13 @@ func GetInterfaceAddresses() (list []string, err error) {
 	}
 
 	return
+}
+
+func WriteStructAndNewLineToFile(f *os.File, s interface{}) (int, error) {
+	outb, err := json.Marshal(s)
+	if err != nil {
+		return 0, err
+	}
+	n, err := f.Write(append(outb, []byte{10}...))
+	return n, err
 }


### PR DESCRIPTION
This PR does the following:

- Implements an Analyze command to grab meaningful statistics and errors from test output files
- Automatically sets the teste ID if one is missing
- Makes the insecure flag a global flag so that server and client both respect TLS
- Changes timers to Microseconds instead of Milliseconds
- Some minor code cleanup and renaming