### PR TITLE
Helm Chart for 5.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+.idea

--- a/helm/hperf/Chart.yaml
+++ b/helm/hperf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hperf
-description: Nperf is a tool for active measurements of the maximum achievable bandwidth between N peers, measuring RX/TX bandwidth for each peers.
+description: hperf is a tool for active measurements of the maximum achievable bandwidth between N peers, measuring RX/TX bandwidth for each peers.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v4.0.5
+version: v5.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.0.5"
+appVersion: "5.0.5"

--- a/helm/hperf/templates/NOTES.txt
+++ b/helm/hperf/templates/NOTES.txt
@@ -1,4 +1,8 @@
 ---
-Look for `hperf` results with `kubectl logs`
+Look for `hperf` bandwidth results
 
-kubectl logs --namespace {{ .Release.Namespace }} --max-log-requests {{ .Values.replicaCount }} -l "app=hperf" -f
+kubectl logs --namespace {{ .Release.Namespace }} --tail=50 -l "app=hperf-bandwidth" -f
+
+Look for `hperf` latency results
+
+kubectl logs --namespace {{ .Release.Namespace }} --tail=50 -l "app=hperf-latency" -f

--- a/helm/hperf/templates/NOTES.txt
+++ b/helm/hperf/templates/NOTES.txt
@@ -1,8 +1,10 @@
 ---
 Look for `hperf` bandwidth results
 
-kubectl logs --namespace {{ .Release.Namespace }} --tail=50 -l "app=hperf-bandwidth" -f
+kubectl logs --namespace {{ .Release.Namespace }} -l "app=hperf-bandwidth" -f
 
+{{- if .Values.latency }}
 Look for `hperf` latency results
 
-kubectl logs --namespace {{ .Release.Namespace }} --tail=50 -l "app=hperf-latency" -f
+kubectl logs --namespace {{ .Release.Namespace }} -l "app=hperf-latency" -f
+{{- end }}

--- a/helm/hperf/templates/bandwith-job.yaml
+++ b/helm/hperf/templates/bandwith-job.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        app: hperf-download
+        app: hperf-bandwidth
         {{- include "hperf.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/helm/hperf/templates/bandwith-job.yaml
+++ b/helm/hperf/templates/bandwith-job.yaml
@@ -61,5 +61,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- end }}

--- a/helm/hperf/templates/bandwith-job.yaml
+++ b/helm/hperf/templates/bandwith-job.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.bandwidth }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "hperf.fullname" . }}-bandwidth
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: hperf-download
+    {{- include "hperf.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: hperf-download
+        {{- include "hperf.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "hperf.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: hperf-download
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "bandwidth"
+            - "--hosts"
+            - {{ range $i, $e := until ($.Values.replicaCount | int) -}}
+              {{ template "hperf.fullname" $ }}-{{ $i }}.{{ template "hperf.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{- if lt (add1 $i) ($.Values.replicaCount | int) }},{{ end -}}
+              {{- end }}
+            - "--port"
+            - "{{ .Values.hperf.port }}"
+            - "--duration"
+            - "{{ .Values.bandwidth.duration }}"
+            - "--concurrency"
+            - "{{ .Values.bandwidth.concurrency }}"
+            - "--id"
+            - {{ .Values.bandwidth.id | default (include "hperf.fullname" .) | quote }}
+            {{- if .Values.bandwidth.printAll }}
+            - "--print-all"
+            {{- end }}
+            {{- if .Values.bandwidth.micro }}
+            - "--micro"
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+{{- end }}

--- a/helm/hperf/templates/bandwith-job.yaml
+++ b/helm/hperf/templates/bandwith-job.yaml
@@ -7,9 +7,6 @@ metadata:
   labels:
     app: hperf-download
     {{- include "hperf.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "1"
 spec:
   template:
     metadata:

--- a/helm/hperf/templates/bandwith-job.yaml
+++ b/helm/hperf/templates/bandwith-job.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app: hperf-download
     {{- include "hperf.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
 spec:
   template:
     metadata:

--- a/helm/hperf/templates/latency-job.yaml
+++ b/helm/hperf/templates/latency-job.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.latency }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "hperf.fullname" . }}-latency
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: hperf-latency
+    {{- include "hperf.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
+spec:
+  template:
+    metadata:
+      labels:
+        app: hperf-latency
+        {{- include "hperf.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "hperf.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: hperf-latency
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "latency"
+            - "--hosts"
+            - {{ range $i, $e := until ($.Values.replicaCount | int) -}}
+            {{ template "hperf.fullname" $ }}-{{ $i }}.{{ template "hperf.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{- if lt (add1 $i) ($.Values.replicaCount | int) }},{{ end -}}
+            {{- end }}
+            - "--port"
+            - "{{ .Values.hperf.port }}"
+            - "--id"
+            - {{ .Values.latency.id | default (include "hperf.fullname" .) | quote }}
+            {{- if .Values.latency.duration }}
+            - "--duration"
+            - "{{ .Values.latency.duration }}"
+            {{- end }}
+            {{- if .Values.bandwidth.printAll }}
+            - "--print-all"
+            {{- end }}
+            {{- if .Values.bandwidth.micro }}
+            - "--micro"
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+{{- end }}

--- a/helm/hperf/templates/latency-job.yaml
+++ b/helm/hperf/templates/latency-job.yaml
@@ -61,5 +61,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- end }}

--- a/helm/hperf/templates/latency-job.yaml
+++ b/helm/hperf/templates/latency-job.yaml
@@ -7,9 +7,6 @@ metadata:
   labels:
     app: hperf-latency
     {{- include "hperf.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "1"
 spec:
   template:
     metadata:

--- a/helm/hperf/templates/service.yaml
+++ b/helm/hperf/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   publishNotReadyAddresses: true
   clusterIP: None  
   ports:
-    - port: 9999
+    - port: {{ .Values.hperf.port }}
       name: http1
   selector:
     app: hperf

--- a/helm/hperf/templates/statefulset.yaml
+++ b/helm/hperf/templates/statefulset.yaml
@@ -32,10 +32,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - "server"
             - "--address"
-            - "0.0.0.0:{{ .Values.hperf.port }}"
+            - "$(POD_IP):{{ .Values.hperf.port }}"
             - "--storage-path"
             - "/tmp/hperf/"
           ports:

--- a/helm/hperf/templates/statefulset.yaml
+++ b/helm/hperf/templates/statefulset.yaml
@@ -42,10 +42,8 @@ spec:
             - name: server
               containerPort: {{ .Values.hperf.port}}
           volumeMounts:
-            {{- if .Values.hperf.hperfVolume.type }}
-            - name: hperf-volume
+            - name: {{ include "hperf.fullname" . }}-volume
               mountPath: /tmp/hperf
-            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -64,24 +62,45 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
       volumes:
-      {{- if .Values.hperf.volumeType }}
-      - name: hperf-volume
-          {{- if eq .Values.hperf.volumeType "emptyDir" }}
+      - name: {{ include "hperf.fullname" . }}-volume
+      {{- if or (hasKey .Values.hperf.hperfVolume "volumeClaimTemplate") (hasKey .Values.hperf.hperfVolume "emptyDir") (hasKey .Values.hperf.hperfVolume "hostPath" ) }}
+        {{- if .Values.hperf.hperfVolume.emptyDir }}
         emptyDir:
-            {{- with .Values.hperf.hperfVolume.emptyDir }}
-            {{- toYaml . | nindent 10 }}
-            {{- end }}
-          {{- else if eq .Values.hperf.volumeType "hostPath" }}
+          {{- with .Values.hperf.hperfVolume.emptyDir }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{ end }}
+        {{- if .Values.hperf.hperfVolume.hostPath }}
         hostPath:
           path: {{ .Values.hperf.hperfVolume.hostPath.path | required "hostPath.path is required when using hostPath volume" }}
           type: {{ .Values.hperf.hperfVolume.hostPath.type | default "DirectoryOrCreate" }}
-            {{- else if eq .Values.hperf.volumeType "persistentVolumeClaim" }}
-        # Default to emptyDir if no volume type specified
-        emptyDir: { }
-            {{- end }}
-        {{- if .Values.hperf.hperfVolume.volumeClaimTemplate }}
-  volumeClaimTemplates:
-    {{- toYaml .Values.hperf.hperfVolume.volumeClaimTemplate | nindent 2 }}
         {{- end }}
+      {{- else }}
+        emptyDir:
+          sizeLimit: 100Mi
+      {{- end }}
+  {{- if .Values.hperf.hperfVolume.volumeClaimTemplate }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "hperf.fullname" . }}-volume
+        {{- with .Values.hperf.hperfVolume.volumeClaimTemplate.storageAnnotations }}
+        annotations: {{- toYaml . | nindent 12 }}
+        {{- end }}
+      spec:
+            {{- if  .Values.hperf.hperfVolume.volumeClaimTemplate.storageClassName }}
+        storageClassName: {{ .Values.hperf.hperfVolume.volumeClaimTemplate.storageClassName }}
+            {{- end }}
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.hperf.hperfVolume.volumeClaimTemplate.size }}
     {{- end }}
+{{- $hasVCT := hasKey .Values.hperf.hperfVolume "volumeClaimTemplate" }}
+{{- $hasEmptyDir := hasKey .Values.hperf.hperfVolume "emptyDir" }}
+{{- $hasHostPath := hasKey .Values.hperf.hperfVolume "hostPath" }}
+{{- if or (and $hasVCT $hasEmptyDir) (and $hasVCT $hasHostPath) (and $hasEmptyDir $hasHostPath) }}
+  {{- fail "Only one volume type can be specified at the time: volumeClaimTemplate, emptyDir, or hostPath" }}
+{{- end }}

--- a/helm/hperf/templates/statefulset.yaml
+++ b/helm/hperf/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
             - "/tmp/hperf/"
           ports:
             - name: server
-              containerPort: {{ .Values.hperf.port | default 9010}}
+              containerPort: {{ .Values.hperf.port}}
           volumeMounts:
             {{- if .Values.hperf.hperfVolume.type }}
             - name: hperf-volume

--- a/helm/hperf/templates/statefulset.yaml
+++ b/helm/hperf/templates/statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: hperf
+    {{- include "hperf.labels" . | nindent 4 }}
 spec:
   serviceName: {{ template "hperf.fullname" . }}
   replicas: {{ .Values.replicaCount }}
@@ -32,12 +33,19 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- range $i := until ($.Values.replicaCount | int)}}
-            - {{ template "hperf.fullname" $ }}-{{ $i }}.{{ template "hperf.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
-            {{ end }}
+            - "server"
+            - "--address"
+            - "0.0.0.0:{{ .Values.hperf.port }}"
+            - "--storage-path"
+            - "/tmp/hperf/"
           ports:
-            - name: http1
-              containerPort: 9999
+            - name: server
+              containerPort: {{ .Values.hperf.port | default 9010}}
+          volumeMounts:
+            {{- if .Values.hperf.hperfVolume.type }}
+            - name: hperf-volume
+              mountPath: /tmp/hperf
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -56,3 +64,24 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      {{- if .Values.hperf.volumeType }}
+      - name: hperf-volume
+          {{- if eq .Values.hperf.volumeType "emptyDir" }}
+        emptyDir:
+            {{- with .Values.hperf.hperfVolume.emptyDir }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
+          {{- else if eq .Values.hperf.volumeType "hostPath" }}
+        hostPath:
+          path: {{ .Values.hperf.hperfVolume.hostPath.path | required "hostPath.path is required when using hostPath volume" }}
+          type: {{ .Values.hperf.hperfVolume.hostPath.type | default "DirectoryOrCreate" }}
+            {{- else if eq .Values.hperf.volumeType "persistentVolumeClaim" }}
+        # Default to emptyDir if no volume type specified
+        emptyDir: { }
+            {{- end }}
+        {{- if .Values.hperf.hperfVolume.volumeClaimTemplate }}
+  volumeClaimTemplates:
+    {{- toYaml .Values.hperf.hperfVolume.volumeClaimTemplate | nindent 2 }}
+        {{- end }}
+    {{- end }}

--- a/helm/hperf/values.yaml
+++ b/helm/hperf/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/minio/hperf
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v4.0.5
+  tag: v5.0.5
 
 imagePullSecrets: []
 
@@ -63,3 +63,52 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+hperf:
+    # Port to run hperf server listening in 0.0.0.0:{{ port }}
+  port: 9010
+  # volumeType: emptyDir, hostPath, persistentVolumeClaim
+  volumeType: emptyDir
+  hperfVolume:
+    emptyDir:
+      sizeLimit: 1Gi
+    # HostPath configuration (used when type: hostPath)
+    # hostPath:
+    #   path: /host/tmp/hperf
+    #   type: DirectoryOrCreate
+
+    # When volumeType is persistentVolumeClaim
+    # volumeClaimTemplate:
+    # - metadata:
+    #     name: data
+    #   spec:
+    #     accessModes: [ "ReadWriteOnce" ]
+    #     resources:
+    #       requests:
+    #         storage: 10Gi
+
+# bandwidth will start hperf as a client in a Job to perform a benchmark of throughput
+# 'hperf bandwidth' uses the chart name as test id by default
+bandwidth:
+  # set a custom test id, default to chart name
+  id: bandwidth-test
+  # duration of the test in seconds
+  duration: 30
+  # number of concurrent clients
+  concurrency: 10
+  # print all data points
+  printAll: false
+  #Display timers in microseconds instead of milliseconds
+  micro: false
+
+# latency will start hperf as a client in a Job to perform a benchmark of latency
+# 'hperf latency' uses the chart name as test id by default
+latency:
+  # set a custom test id, default to chart name
+  id: latency-test
+  controls how long a test will run in seconds (default: 30)
+  duration: 30
+  # print all data points
+  printAll: false
+  #Display timers in microseconds instead of milliseconds
+  micro: false

--- a/helm/hperf/values.yaml
+++ b/helm/hperf/values.yaml
@@ -89,7 +89,6 @@ hperf:
 #      storageAnnotations: {}
 
 # bandwidth will start hperf as a client in a Job to perform a benchmark of throughput
-# 'hperf bandwidth' uses the chart name as test id by default
 bandwidth:
   labels: {}
   # set a custom test id, default to chart name
@@ -103,15 +102,14 @@ bandwidth:
   #Display timers in microseconds instead of milliseconds
   micro: false
 
-# latency will start hperf as a client in a Job to perform a benchmark of latency
-# 'hperf latency' uses the chart name as test id by default
-latency:
-  labels: {}
-  # set a custom test id, default to chart name
-  id: latency-test
-  controls how long a test will run in seconds (default: 30)
-  duration: 30
-  # print all data points
-  printAll: true
-  #Display timers in microseconds instead of milliseconds
-  micro: false
+## latency will start hperf as a client in a Job to perform a benchmark of latency
+#latency:
+#  labels: {}
+#  # set a custom test id, default to chart name
+#  id: latency-test
+#  controls how long a test will run in seconds (default: 30)
+#  duration: 30
+#  # print all data points
+#  printAll: true
+#  #Display timers in microseconds instead of milliseconds
+#  micro: false

--- a/helm/hperf/values.yaml
+++ b/helm/hperf/values.yaml
@@ -65,6 +65,7 @@ tolerations: []
 affinity: {}
 
 hperf:
+  labels: {}
     # Port to run hperf server listening in 0.0.0.0:{{ port }}
   port: 9010
   # volumeType: emptyDir, hostPath, persistentVolumeClaim
@@ -90,6 +91,7 @@ hperf:
 # bandwidth will start hperf as a client in a Job to perform a benchmark of throughput
 # 'hperf bandwidth' uses the chart name as test id by default
 bandwidth:
+  labels: {}
   # set a custom test id, default to chart name
   id: bandwidth-test
   # duration of the test in seconds
@@ -104,6 +106,7 @@ bandwidth:
 # latency will start hperf as a client in a Job to perform a benchmark of latency
 # 'hperf latency' uses the chart name as test id by default
 latency:
+  labels: {}
   # set a custom test id, default to chart name
   id: latency-test
   controls how long a test will run in seconds (default: 30)

--- a/helm/hperf/values.yaml
+++ b/helm/hperf/values.yaml
@@ -68,25 +68,25 @@ hperf:
   labels: {}
     # Port to run hperf server listening in 0.0.0.0:{{ port }}
   port: 9010
-  # volumeType: emptyDir, hostPath, persistentVolumeClaim
-  volumeType: emptyDir
+
+  # Type of volume to use. Supported types are emptyDir hostPath and persistentVolumeClaim
+  # WARNING: Only one volume type can be specified at the time: volumeClaimTemplate, emptyDir, or hostPath
   hperfVolume:
     emptyDir:
       sizeLimit: 1Gi
-    # HostPath configuration (used when type: hostPath)
-    # hostPath:
-    #   path: /host/tmp/hperf
-    #   type: DirectoryOrCreate
+
+#     HostPath configuration (used when type: hostPath)
+#     hostPath:
+#       path: /host/tmp/hperf
+#       type: DirectoryOrCreate
 
     # When volumeType is persistentVolumeClaim
-    # volumeClaimTemplate:
-    # - metadata:
-    #     name: data
-    #   spec:
-    #     accessModes: [ "ReadWriteOnce" ]
-    #     resources:
-    #       requests:
-    #         storage: 10Gi
+#    volumeClaimTemplate:
+#      # The capacity for the volume
+#      size: 100Mi
+#      #storageClassName: standard
+#      # Specify `storageAnnotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`__
+#      storageAnnotations: {}
 
 # bandwidth will start hperf as a client in a Job to perform a benchmark of throughput
 # 'hperf bandwidth' uses the chart name as test id by default

--- a/helm/hperf/values.yaml
+++ b/helm/hperf/values.yaml
@@ -99,7 +99,7 @@ bandwidth:
   # number of concurrent clients
   concurrency: 10
   # print all data points
-  printAll: false
+  printAll: true
   #Display timers in microseconds instead of milliseconds
   micro: false
 
@@ -112,6 +112,6 @@ latency:
   controls how long a test will run in seconds (default: 30)
   duration: 30
   # print all data points
-  printAll: false
+  printAll: true
   #Display timers in microseconds instead of milliseconds
   micro: false


### PR DESCRIPTION
Helm chart 5.0.5

Changes in this release:
- Converted bandwidth Pod to Job for one-time test execution
- Converted latency Pod to Job with post-install hook for automated testing
- Updated Chart version to 5.0.5
- Enhanced StatefulSet configuration with improved resource management
- Added new configuration options in values.yaml for test parameters
- Fixed service port configuration to use integer type

These changes provide better Kubernetes-native handling of test workloads,
ensuring proper completion tracking and automatic cleanup of finished tests.