### PR TITLE
Update hperf helm chart to 5.0.6

### DIFF
--- a/helm/hperf/Chart.yaml
+++ b/helm/hperf/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v5.0.5
+version: v5.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.5"
+appVersion: "5.0.6"

--- a/helm/hperf/values.yaml
+++ b/helm/hperf/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/minio/hperf
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v5.0.5
+  tag: v5.0.6
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This wil make so that the helm chart uses the image for v5.0.6 once is published